### PR TITLE
Add imageio as dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ VERSION = '0.0.2'
 
 INSTALL_REQUIRES = (
     ['mujoco >= 2.1.2',
-     'glfw >= 2.5.0']
+     'glfw >= 2.5.0',
+     'imageio']
 )
 
 setup(


### PR DESCRIPTION
Hi! First of all, thank you for implementing this package! 

I tried to install it by following the documentation in the readme (i.e. `pip install mujoco-python-viewer`)
However, when I try to import `mujoco_viewer` I get the following error
```python
Python 3.8.10 (default, Mar 15 2022, 12:22:08) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import mujoco
>>> import mujoco_viewer
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/gromualdi/venv/test-mujoco/lib/python3.8/site-packages/mujoco_viewer/__init__.py", line 1, in <module>
    from mujoco_viewer.mujoco_viewer import MujocoViewer
  File "/home/gromualdi/venv/test-mujoco/lib/python3.8/site-packages/mujoco_viewer/mujoco_viewer.py", line 7, in <module>
    import imageio
ModuleNotFoundError: No module named 'imageio'
```

This PR adds `imageio` as a dependency in the `setup.py`