### PR TITLE
Added ability to toggle on/off the small bottom-left menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ Other key bindings are shown in the overlay menu (almost similar to `mujoco-py`)
 - `title`: set the title of the window, for example: `viewer = mujoco_viewer.MujocoViewer(model, data, title='My Demo')` (defaults to `mujoco-python-viewer`). 
 - `width`: set the window width, for example: `viewer = mujoco_viewer.MujocoViewer(model, data, width=300)` (defaults to full screen's width). 
 - `height`: set the window height, for example: `viewer = mujoco_viewer.MujocoViewer(model, data, height=300)` (defaults to full screen's height). 
+- `hide_menus`: set whether the overlay menus should be hidden or not (defaults to `True`).

--- a/mujoco_viewer/mujoco_viewer.py
+++ b/mujoco_viewer/mujoco_viewer.py
@@ -14,7 +14,8 @@ class MujocoViewer:
             data,
             title="mujoco-python-viewer",
             width=None,
-            height=None):
+            height=None,
+            hide_statistics_menu=False):
         self.model = model
         self.data = data
 
@@ -41,7 +42,8 @@ class MujocoViewer:
         self._run_speed = 1.0
         self._loop_count = 0
         self._advance_by_one_step = False
-        self._hide_menu = True
+        self._hide_help_menu = True
+        self._hide_statistics_menu = hide_statistics_menu
 
         # glfw init
         glfw.init()
@@ -90,7 +92,7 @@ class MujocoViewer:
     def _key_callback(self, window, key, scancode, action, mods):
         if action != glfw.RELEASE:
             if key == glfw.KEY_LEFT_ALT:
-                self._hide_menu = False
+                self._hide_help_menu = False
             return
         # Switch cameras
         elif key == glfw.KEY_TAB:
@@ -137,9 +139,11 @@ class MujocoViewer:
             self.vopt.frame = 1 - self.vopt.frame
         # Hide overlay menu
         elif key == glfw.KEY_LEFT_ALT:
-            self._hide_menu = True
+            self._hide_help_menu = True
         elif key == glfw.KEY_H:
-            self._hide_menu = not self._hide_menu
+            self._hide_help_menu = not self._hide_help_menu
+        elif key == glfw.KEY_A:
+            self._hide_statistics_menu = not self._hide_statistics_menu
         # Make transparent
         elif key == glfw.KEY_R:
             self._transparent = not self._transparent
@@ -457,7 +461,8 @@ class MujocoViewer:
             topleft,
             "Referenc[e] frames",
             "On" if self.vopt.frame == 1 else "Off")
-        add_overlay(topleft, "[H]ide Menu", "")
+        add_overlay(topleft, "[H]ide Help Menu (this menu)", "")
+        add_overlay(topleft, "Hide St[A]tistics Menu (bottom-left menu)", "")
         if self._image_idx > 0:
             fname = self._image_path % (self._image_idx - 1)
             add_overlay(topleft, "Cap[t]ure frame", "Saved as %s" % fname)
@@ -513,8 +518,12 @@ class MujocoViewer:
                 mujoco.mjr_render(self.viewport, self.scn, self.ctx)
                 # overlay items
                 for gridpos, [t1, t2] in self._overlay.items():
-                    if gridpos == mujoco.mjtGridPos.mjGRID_TOPLEFT and self._hide_menu:
+                    if gridpos == mujoco.mjtGridPos.mjGRID_TOPLEFT and self._hide_help_menu:
                         continue
+
+                    if gridpos == mujoco.mjtGridPos.mjGRID_BOTTOMLEFT and self._hide_statistics_menu:
+                        continue
+
                     mujoco.mjr_overlay(
                         mujoco.mjtFontScale.mjFONTSCALE_150,
                         gridpos,

--- a/mujoco_viewer/mujoco_viewer.py
+++ b/mujoco_viewer/mujoco_viewer.py
@@ -15,7 +15,7 @@ class MujocoViewer:
             title="mujoco-python-viewer",
             width=None,
             height=None,
-            hide_statistics_menu=False):
+            hide_menus=True):
         self.model = model
         self.data = data
 
@@ -42,8 +42,7 @@ class MujocoViewer:
         self._run_speed = 1.0
         self._loop_count = 0
         self._advance_by_one_step = False
-        self._hide_help_menu = True
-        self._hide_statistics_menu = hide_statistics_menu
+        self._hide_menus = hide_menus
 
         # glfw init
         glfw.init()
@@ -92,7 +91,7 @@ class MujocoViewer:
     def _key_callback(self, window, key, scancode, action, mods):
         if action != glfw.RELEASE:
             if key == glfw.KEY_LEFT_ALT:
-                self._hide_help_menu = False
+                self._hide_menus = False
             return
         # Switch cameras
         elif key == glfw.KEY_TAB:
@@ -139,11 +138,9 @@ class MujocoViewer:
             self.vopt.frame = 1 - self.vopt.frame
         # Hide overlay menu
         elif key == glfw.KEY_LEFT_ALT:
-            self._hide_help_menu = True
+            self._hide_menus = True
         elif key == glfw.KEY_H:
-            self._hide_help_menu = not self._hide_help_menu
-        elif key == glfw.KEY_A:
-            self._hide_statistics_menu = not self._hide_statistics_menu
+            self._hide_menus = not self._hide_menus
         # Make transparent
         elif key == glfw.KEY_R:
             self._transparent = not self._transparent
@@ -461,8 +458,7 @@ class MujocoViewer:
             topleft,
             "Referenc[e] frames",
             "On" if self.vopt.frame == 1 else "Off")
-        add_overlay(topleft, "[H]ide Help Menu (this menu)", "")
-        add_overlay(topleft, "Hide St[A]tistics Menu (bottom-left menu)", "")
+        add_overlay(topleft, "[H]ide Menus", "")
         if self._image_idx > 0:
             fname = self._image_path % (self._image_idx - 1)
             add_overlay(topleft, "Cap[t]ure frame", "Saved as %s" % fname)
@@ -518,10 +514,9 @@ class MujocoViewer:
                 mujoco.mjr_render(self.viewport, self.scn, self.ctx)
                 # overlay items
                 for gridpos, [t1, t2] in self._overlay.items():
-                    if gridpos == mujoco.mjtGridPos.mjGRID_TOPLEFT and self._hide_help_menu:
-                        continue
-
-                    if gridpos == mujoco.mjtGridPos.mjGRID_BOTTOMLEFT and self._hide_statistics_menu:
+                    menu_positions = [mujoco.mjtGridPos.mjGRID_TOPLEFT,
+                                      mujoco.mjtGridPos.mjGRID_BOTTOMLEFT]
+                    if gridpos in menu_positions and self._hide_menus:
                         continue
 
                     mujoco.mjr_overlay(


### PR DESCRIPTION
Sometimes, especially for experiments, it's good to have a clean window without any menus to take screenshots. I added a small code that provides a toggle to turn on or off the bottom-left stats menu. I also added an optional parameter to turn it off when initializing the viewer. By default, nothing changes, the stats menu will be visible as like before.

I had to introduce two different names for these menus: `help_menu` for the previous menu and `statistics_menu` for the bottom-left one.