### PR TITLE
Add pyyaml as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ VERSION = '0.1.2'
 INSTALL_REQUIRES = (
     ['mujoco >= 2.1.5',
      'glfw >= 2.5.0',
-     'imageio']
+     'imageio',
+     'pyyaml']
 )
 
 setup(


### PR DESCRIPTION
Thanks for providing this package! While packaging it for conda-forge (https://github.com/conda-forge/staged-recipes/pull/23289), I noticed that `import yaml` is used in the code, but not mentioned in the `setup.py`. I think this PR should fix the problem.